### PR TITLE
feat: ignore warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,8 @@ Pronto runner for [xmllint](http://xmlsoft.org/xmllint.html). [What is Pronto?](
 ## Prerequisites
 
 You need to have `xmllint` present in the system, found via `$PATH`
+
+
+## Changelog
+
+0.2.0 Added option to not complain on warnings.

--- a/lib/pronto/xmllint_runner.rb
+++ b/lib/pronto/xmllint_runner.rb
@@ -48,7 +48,7 @@ module Pronto
       def run_xmllint(patch)
         Dir.chdir(repo_path) do
           escaped_file_path = Shellwords.escape(patch.new_file_full_path.to_s)
-          `xmllint --noout #{escaped_file_path}`
+          `xmllint --nowarning --noout #{escaped_file_path}`
         end
         return $?.exitstatus
       end

--- a/lib/pronto/xmllint_version.rb
+++ b/lib/pronto/xmllint_version.rb
@@ -1,5 +1,5 @@
 module Pronto
   module XMLLintVersion
-    VERSION = '0.1.1'.freeze
+    VERSION = '0.2.0'.freeze
   end
 end


### PR DESCRIPTION
XMLLint emits warnings for things like:
```
parser warning : Unsupported version '1.1'
<?xml version='1.1' encoding='UTF-8'?>
```
because of `libxml2`, thus breaking my CI/CD stuff.
Probably I should switch to something else one day.