### PR TITLE
feat: update for ruby 2.7

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Paulius M.
+Copyright (c) 2022 Paulius M.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ You need to have `xmllint` present in the system, found via `$PATH`
 
 ## Changelog
 
+0.3.1 Fixes for ruby 2.7
+
 0.3.0 Depend on pronto v0.1.1
 
 0.2.0 Added option to not complain on warnings.

--- a/lib/pronto/xmllint_runner.rb
+++ b/lib/pronto/xmllint_runner.rb
@@ -37,6 +37,7 @@ module Pronto
 
       def inspect(patch)
         new_message('XMLLint failed.') if run_xmllint(patch).nonzero?
+        []
       end
 
       def new_message(offence)

--- a/lib/pronto/xmllint_version.rb
+++ b/lib/pronto/xmllint_version.rb
@@ -1,5 +1,5 @@
 module Pronto
   module XMLLintVersion
-    VERSION = '0.3.0'.freeze
+    VERSION = '0.3.1'.freeze
   end
 end


### PR DESCRIPTION
Fixes 
```
.../gems/pronto-xmllint-0.3.0/lib/pronto/xmllint_runner.rb:17:in `concat': no implicit conversion of nil into Array (TypeError)
```